### PR TITLE
adds name and GO: prefix for GO term to obsoletion report

### DIFF
--- a/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
+++ b/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
@@ -92,7 +92,7 @@ class GoTermsUpdater
 		}
 		String dateString = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
 		this.newMFPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/new_molecular_functions_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO ID", "GO Term Name", "Definition") );
-		this.obsoleteAccessionPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/obsolete_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Type", "Obsolete Term", "Suggested action", "New/replacement GO Terms") );
+		this.obsoleteAccessionPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/obsolete_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Type", "Obsolete GO Accession", "Obsolete GO Term Name", "Suggested action", "New/replacement GO Terms") );
 		this.newGOTermsPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/new_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Term Name", "GO Term ID", "GO Term Type", "Definition") );
 		this.categoryMismatchPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/category_mismatch_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO ID", "Category in Database", "Category in file") );
 		this.replacedGOTermsPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/replaced_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Term Name", "Primary accession", "Primary Class", "DB_ID (Secondary; to be deleted)", "Secondary accession (to be deleted)", "Secondary Class", "Referrers to be automatically redirected to Primary accession") );
@@ -348,7 +348,14 @@ class GoTermsUpdater
 				{
 					action = "Automatic Deletion (no referrers)";
 				}
-				this.obsoleteAccessionPrinter.printRecord(instance.getDBID(), instance.getSchemClass().getName(), instance.getAttributeValue(ReactomeJavaConstants.accession), action, replacementGOTermAccession);
+				this.obsoleteAccessionPrinter.printRecord(
+					instance.getDBID(),
+					instance.getSchemClass().getName(),
+					"GO:" + instance.getAttributeValue(ReactomeJavaConstants.accession),
+					instance.getDisplayName(),
+					action,
+					replacementGOTermAccession
+				);
 				goTermModifier.deleteGoInstance(goTermsFromFile, allGoInstances, this.deletionStringBuilder);
 				deletedCount ++;
 			}
@@ -397,7 +404,14 @@ class GoTermsUpdater
 					consider = considerList != null && !considerList.isEmpty() ? "Consider: " + String.join(", ", considerList) : "";
 					String replacementTermString = replaceBy + consider;
 					replacementTermString = replacementTermString.length() == 0 ? "N/A" : replacementTermString;
-					obsoleteAccessionPrinter.printRecord(inst.getDBID(), inst.getSchemClass().getName(), inst.getAttributeValue(ReactomeJavaConstants.accession), "Manual cleanup (referrers exist)", replacementTermString);
+					obsoleteAccessionPrinter.printRecord(
+						inst.getDBID(),
+						inst.getSchemClass().getName(),
+						"GO:" + inst.getAttributeValue(ReactomeJavaConstants.accession),
+						inst.getDisplayName(),
+						"Manual cleanup (referrers exist)",
+						replacementTermString
+					);
 				}
 			}
 			catch (Exception e)


### PR DESCRIPTION
This PR adds the GO term name and "GO:" prefix to the accession for the reported obsolete GO terms.