### PR TITLE
Feature/exclude plant obsolete terms

### DIFF
--- a/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
+++ b/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
@@ -43,6 +43,7 @@ class GoTermsUpdater
 
 	private CSVPrinter newMFPrinter;
 	private CSVPrinter obsoleteAccessionPrinter;
+	private CSVPrinter plantObsoleteAccessionPrinter;
 	private CSVPrinter newGOTermsPrinter;
 	private CSVPrinter replacedGOTermsPrinter;
 	private CSVPrinter categoryMismatchPrinter;
@@ -93,6 +94,7 @@ class GoTermsUpdater
 		String dateString = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
 		this.newMFPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/new_molecular_functions_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO ID", "GO Term Name", "Definition") );
 		this.obsoleteAccessionPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/obsolete_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Type", "Obsolete Term", "Suggested action", "New/replacement GO Terms") );
+		this.plantObsoleteAccessionPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/plant_obsolete_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Type", "Obsolete Term", "Suggested action", "New/replacement GO Terms") );
 		this.newGOTermsPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/new_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Term Name", "GO Term ID", "GO Term Type", "Definition") );
 		this.categoryMismatchPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/category_mismatch_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO ID", "Category in Database", "Category in file") );
 		this.replacedGOTermsPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/replaced_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Term Name", "Primary accession", "Primary Class", "DB_ID (Secondary; to be deleted)", "Secondary accession (to be deleted)", "Secondary Class", "Referrers to be automatically redirected to Primary accession") );
@@ -267,6 +269,7 @@ class GoTermsUpdater
 		this.newGOTermsPrinter.close();
 		this.newMFPrinter.close();
 		this.obsoleteAccessionPrinter.close();
+		this.plantObsoleteAccessionPrinter.close();
 		this.replacedGOTermsPrinter.close();
 
 		return mainOutput;
@@ -401,6 +404,8 @@ class GoTermsUpdater
 
 					if (!isPlantOnlyGOTerm(inst)) {
 						obsoleteAccessionPrinter.printRecord(inst.getDBID(), inst.getSchemClass().getName(), inst.getAttributeValue(ReactomeJavaConstants.accession), "Manual cleanup (referrers exist)", replacementTermString);
+					} else {
+						plantObsoleteAccessionPrinter.printRecord(inst.getDBID(), inst.getSchemClass().getName(), inst.getAttributeValue(ReactomeJavaConstants.accession), "Manual cleanup (referrers exist)", replacementTermString);
 					}
 				}
 			}

--- a/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
+++ b/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
@@ -4,13 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -634,22 +628,38 @@ class GoTermsUpdater
 
 	private static boolean isPlantOnlyInstance(GKInstance instance) {
 		if (instance.getSchemClass().isa(ReactomeJavaConstants.CatalystActivity)) {
-			Collection<GKInstance> reactionLikeEvents;
-			try {
-				reactionLikeEvents = instance.getReferers(ReactomeJavaConstants.catalystActivity);
-			} catch (Exception e) {
-				throw new RuntimeException("Unable to get referrers for CatalystActivity " + instance, e);
-			}
-			return reactionLikeEvents.stream().allMatch(reactionLikeEvent -> isPlantOnlyInstance(reactionLikeEvent));
+			return getReactionLikeEventReferrers(instance).stream().allMatch(reactionLikeEvent -> isPlantOnlyInstance(reactionLikeEvent));
 		}
 
-		List<GKInstance> speciesInstances;
+		return getSpeciesInstances(instance)
+			.stream()
+			.allMatch(speciesInstance -> getPlantSpeciesDisplayNames().contains(speciesInstance.getDisplayName()));
+	}
+
+	private static List<GKInstance> getReactionLikeEventReferrers(GKInstance catalystActivityInstance) {
+		Collection<GKInstance> referrers;
 		try {
-			speciesInstances = instance.getAttributeValuesList(ReactomeJavaConstants.species);
+			referrers = catalystActivityInstance.getReferers(ReactomeJavaConstants.catalystActivity);
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to get referrers for CatalystActivity " + catalystActivityInstance, e);
+		}
+
+		if (referrers == null) {
+			return Collections.emptyList();
+		}
+
+		return referrers
+			.stream()
+			.filter(referrer -> referrer.getSchemClass().isa(ReactomeJavaConstants.ReactionlikeEvent))
+			.collect(Collectors.toList());
+	}
+
+	private static List<GKInstance> getSpeciesInstances(GKInstance instance) {
+		try {
+			return instance.getAttributeValuesList(ReactomeJavaConstants.species);
 		} catch (Exception e) {
 			throw new RuntimeException("Unable to get species instances for " + instance, e);
 		}
-		return speciesInstances.stream().allMatch(speciesInstance -> getPlantSpeciesDisplayNames().contains(speciesInstance.getDisplayName()));
 	}
 
 	private static List<String> getPlantSpeciesDisplayNames() {

--- a/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
+++ b/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
@@ -88,8 +88,8 @@ class GoTermsUpdater
 		String dateString = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
 		this.newMFPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/new_molecular_functions_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO ID", "GO Term Name", "Definition") );
 
-		this.obsoleteAccessionPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/obsolete_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Type", "Obsolete GO Term Name", "Obsolete GO Term Accession", "Suggested action", "New/replacement GO Terms") );
-		this.plantObsoleteAccessionPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/plant_obsolete_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Type", "Obsolete GO Term Name", "Obsolete GO Term Accession", "Suggested action", "New/replacement GO Terms") );
+		this.obsoleteAccessionPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/obsolete_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Type", "Obsolete GO Term Accession", "Obsolete GO Term Name", "Suggested action", "New/replacement GO Terms") );
+		this.plantObsoleteAccessionPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/plant_obsolete_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Type", "Obsolete GO Term Accession", "Obsolete GO Term Name", "Suggested action", "New/replacement GO Terms") );
 
 		this.newGOTermsPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/new_GO_terms_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO Term Name", "GO Term ID", "GO Term Type", "Definition") );
 		this.categoryMismatchPrinter = new CSVPrinter(Files.newBufferedWriter(Paths.get("reports/category_mismatch_"+dateString+".csv")), GO_REPORT_FORMAT.withHeader("DB_ID", "GO ID", "Category in Database", "Category in file") );

--- a/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
+++ b/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
@@ -348,6 +348,7 @@ class GoTermsUpdater
 				{
 					action = "Automatic Deletion (no referrers)";
 				}
+
 				this.obsoleteAccessionPrinter.printRecord(instance.getDBID(), instance.getSchemClass().getName(), instance.getAttributeValue(ReactomeJavaConstants.accession), action, replacementGOTermAccession);
 				goTermModifier.deleteGoInstance(goTermsFromFile, allGoInstances, this.deletionStringBuilder);
 				deletedCount ++;
@@ -397,7 +398,10 @@ class GoTermsUpdater
 					consider = considerList != null && !considerList.isEmpty() ? "Consider: " + String.join(", ", considerList) : "";
 					String replacementTermString = replaceBy + consider;
 					replacementTermString = replacementTermString.length() == 0 ? "N/A" : replacementTermString;
-					obsoleteAccessionPrinter.printRecord(inst.getDBID(), inst.getSchemClass().getName(), inst.getAttributeValue(ReactomeJavaConstants.accession), "Manual cleanup (referrers exist)", replacementTermString);
+
+					if (!plantOnlyGOTerm(inst)) {
+						obsoleteAccessionPrinter.printRecord(inst.getDBID(), inst.getSchemClass().getName(), inst.getAttributeValue(ReactomeJavaConstants.accession), "Manual cleanup (referrers exist)", replacementTermString);
+					}
 				}
 			}
 			catch (Exception e)
@@ -616,5 +620,37 @@ class GoTermsUpdater
 				goToECNumbers.put(goNumber, ecNumbers);
 			}
 		}
+	}
+
+	private static boolean isPlantOnlyGOTerm(GKInstance goInstance) throws Exception {
+		List<GKInstance> referrers = getReferrersFilteredByClass(goInstance, isNotGOEntity);
+		return referrers.stream().allMatch(referrer -> isPlantOnlyInstance(referrer));
+	}
+
+	private static boolean isPlantOnlyInstance(GKInstance instance) {
+		if (instance.getSchemClass().isa(ReactomeJavaConstants.CatalystActivity)) {
+			Collection<GKInstance> reactionLikeEvents;
+			try {
+				reactionLikeEvents = instance.getReferers(ReactomeJavaConstants.catalystActivity);
+			} catch (Exception e) {
+				throw new RuntimeException("Unable to get referrers for CatalystActivity " + instance, e);
+			}
+			return reactionLikeEvents.stream().allMatch(reactionLikeEvent -> isPlantOnlyInstance(reactionLikeEvent));
+		}
+
+		List<GKInstance> speciesInstances;
+		try {
+			speciesInstances = instance.getAttributeValuesList(ReactomeJavaConstants.species);
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to get species instances for " + instance, e);
+		}
+		return speciesInstances.stream().allMatch(speciesInstance -> getPlantSpeciesDisplayNames().contains(speciesInstance.getDisplayName()));
+	}
+
+	private static List<String> getPlantSpeciesDisplayNames() {
+		return Arrays.asList(
+			"Arabidopsis thaliana",
+			"Oryza sativa"
+		);
 	}
 }

--- a/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
+++ b/src/main/java/org/reactome/release/goupdate/GoTermsUpdater.java
@@ -399,7 +399,7 @@ class GoTermsUpdater
 					String replacementTermString = replaceBy + consider;
 					replacementTermString = replacementTermString.length() == 0 ? "N/A" : replacementTermString;
 
-					if (!plantOnlyGOTerm(inst)) {
+					if (!isPlantOnlyGOTerm(inst)) {
 						obsoleteAccessionPrinter.printRecord(inst.getDBID(), inst.getSchemClass().getName(), inst.getAttributeValue(ReactomeJavaConstants.accession), "Manual cleanup (referrers exist)", replacementTermString);
 					}
 				}

--- a/src/test/java/org/reactome/release/goupdate/DuplicateReporterIT.java
+++ b/src/test/java/org/reactome/release/goupdate/DuplicateReporterIT.java
@@ -35,7 +35,7 @@ public class DuplicateReporterIT
 	
 	
 	@Test
-	public void testGetDuplicateAccessions() throws SQLException
+	public void testGetDuplicateAccessions() throws Exception
 	{
 		DuplicateReporter dupeReporter = new DuplicateReporter(adaptor);
 		


### PR DESCRIPTION
This PR separates GO terms only used for plant instances in gk_central into their own report.  This will help keep focus on GO terms that are human and other species in "main" Reactome.